### PR TITLE
Updated getWebsitePageContentByTitle

### DIFF
--- a/src/data/website-pages-content-item/data-source.js
+++ b/src/data/website-pages-content-item/data-source.js
@@ -10,7 +10,13 @@ const normalizeWebPageTitle = (title) => lowerCase(title).replace(/\s/g, '');
 
 export default class WebsitePagesContentItem extends ContentItem.dataSource {
     getWebsitePageContentByTitle = async (website, title) => {
-        console.log("Running getWebsitePageContentByTitle...");
+        // query ContentChannelItemSlugs by the title passed in
+        // select the ContentChannelItemId
+        const contentChannelItemIds = await this
+            .request('ContentChannelItemSlugs')
+            .filter(`Slug eq '${normalizeWebPageTitle(title)}'`)
+            .select('ContentChannelItemId, Slug')
+            .get();
 
         // Get the Content Channels for the specified Website
         const websiteContentChannelIds = get(
@@ -18,21 +24,21 @@ export default class WebsitePagesContentItem extends ContentItem.dataSource {
             `WEBSITE_CONTENT_CHANNEL_IDS.${website}`,
             null);
 
-        if (websiteContentChannelIds) {
-            // Get the Content Channel Items from Content Channel Id
+        if (websiteContentChannelIds.length && contentChannelItemIds.length) {
+            // query ContentChannelItems by ContentChannelId and ContentChannelItemId
+            // return the first result (we only want 1 item to be passed back since page title to page should be a 1-1 relationship)
+            const { contentChannelItemId } = first(contentChannelItemIds)
             const websiteContentChannelItems = await this.request()
-                .filter(websiteContentChannelIds.map(
-                    (channelId) => `(ContentChannelId eq ${channelId})`
-                ).join(' or '))
+                .filter(
+                    `(${websiteContentChannelIds.map(
+                        (channelId) => `(ContentChannelId eq ${channelId})`
+                    ).join(' or ')}) and (Id eq ${contentChannelItemId})`
+                )
                 .get();
 
             if (websiteContentChannelItems) {
-                // Find top 1 page whose 
-                return first(
-                    websiteContentChannelItems.filter(
-                        (item) => normalizeWebPageTitle(get(item, 'title', '')) === normalizeWebPageTitle(title)
-                    )
-                );
+                // Find top 1 page
+                return first(websiteContentChannelItems);
             }
         }
 

--- a/src/data/website-pages-content-item/resolver.js
+++ b/src/data/website-pages-content-item/resolver.js
@@ -4,6 +4,14 @@ import {
     get
 } from 'lodash'
 
+const parseProtocols = (str) => str
+    ? str.split('|')
+        .map((n) => {
+            var splt = n.split('^')
+            return { content: splt[0] || '', name: splt[1] || '' };
+        })
+    : []
+
 const resolver = {
     Query: {
         getWebsitePageContentByTitle: async (root, { website, title }, context) =>
@@ -19,6 +27,10 @@ const resolver = {
                 .filter((n) => {
                     return n !== '';
                 }),
+        openGraphProtocols: ({ attributeValues }) =>
+            parseProtocols(get(attributeValues, 'openGraphProtocols.value', null)),
+        twitterProtocols: ({ attributeValues }) =>
+            parseProtocols(get(attributeValues, 'twitterProtocols.value', null)),
     }
 }
 

--- a/src/data/website-pages-content-item/schema.js
+++ b/src/data/website-pages-content-item/schema.js
@@ -6,6 +6,11 @@ export default gql`
         getWebsitePageContentByTitle(website: String!, title: String!): WebsitePagesContentItem
     }
 
+    type MetaTag {
+        name: String
+        content: String
+    }
+
     type WebsitePagesContentItem implements ContentItem & Node {
         id: ID!
         title: String
@@ -28,5 +33,7 @@ export default gql`
 
         metaDescription: String
         metaKeywords: [String]
+        openGraphProtocols: [MetaTag]
+        twitterProtocols: [MetaTag]
     }
 `;


### PR DESCRIPTION
Update the query for getting Web Pages to respect the Item's Url Slugs set in Rock. The item must be both in the correct Content Channel for Web Pages and also have a Url Slug set in Rock