### PR TITLE
Hot Fix

### DIFF
--- a/src/data/__tests__/utils.tests.js
+++ b/src/data/__tests__/utils.tests.js
@@ -20,6 +20,10 @@ describe('ParseRockKeyValuePairs', () => {
         expect(parseRockKeyValuePairs(str, 'keyOverride', 'valueOverride')).toMatchSnapshot()
     })
 
+    it('is passed an empty string for the keyValueStr attribute and returns null', () => {
+        expect(parseRockKeyValuePairs('')).toEqual(null)
+    })
+
     it('is passed null for the keyValueStr attribute and returns null', () => {
         expect(parseRockKeyValuePairs(null)).toEqual(null)
     })

--- a/src/data/utils.js
+++ b/src/data/utils.js
@@ -5,6 +5,8 @@ export const parseRockKeyValuePairs = (keyValueStr, keyOverride = null, valueOve
   const key = keyOverride || 'key'
   const value = valueOverride || 'value'
 
+  console.log("Parsing Key Value Pairs: ", { keyValueStr })
+
   return keyValueStr
     ? keyValueStr.split('|')
       .map((n) => {
@@ -16,5 +18,5 @@ export const parseRockKeyValuePairs = (keyValueStr, keyOverride = null, valueOve
 
         return rtn
       })
-    : keyValueStr
+    : null
 }


### PR DESCRIPTION
Key value pair returns null when an invalid string is passed in to fix the iterable error.